### PR TITLE
Fix distutils issue in 3.12+

### DIFF
--- a/pymiere/core.py
+++ b/pymiere/core.py
@@ -4,7 +4,7 @@ Core functions handling connection and objects base
 import os
 import sys
 import json
-from distutils.version import StrictVersion
+from packaging.version import Version
 from time import time as current_time
 import requests
 from pymiere.exe_utils import is_premiere_running
@@ -57,11 +57,11 @@ def get_premiere_version():
     """
     Query or get from cache the version of the currently running Premiere pro
 
-    :return: (StrictVersion) version object of current premiere pro
+    :return: (Version) version object of current premiere pro
     """
     global premiere_pro_version
     if "premiere_pro_version" not in globals():
-        premiere_pro_version = StrictVersion(eval_script("app.version;"))
+        premiere_pro_version = Version(eval_script("app.version;"))
     return premiere_pro_version
 
 
@@ -231,14 +231,14 @@ class PymiereBaseObject(object):
         Check to use in subclass when creating a new property or method only available from a specific premiere
         version to check and raise if it is not available because we are using an older premiere version
 
-        :param minimum_version: (str or StrictVersion) minimum version requirement to use this property/method
+        :param minimum_version: (str or Version) minimum version requirement to use this property/method
         :param name: (str) name of the method/property
         :param alternative_msg: (None or str) if given provide an alternative solution in the error message to achieve
         the same behaviour with different code
         """
         current_version = get_premiere_version()
-        if not isinstance(minimum_version, StrictVersion):
-            minimum_version = StrictVersion(minimum_version)
+        if not isinstance(minimum_version, Version):
+            minimum_version = Version(minimum_version)
         if current_version >= minimum_version:
             return
         message = "'{}' is only available from Premiere Pro v{} and you are using v{}.".format(

--- a/pymiere/exe_utils.py
+++ b/pymiere/exe_utils.py
@@ -9,7 +9,7 @@ import time
 import re
 import json
 import subprocess
-from distutils.version import StrictVersion
+from packaging.version import Version
 import platform
 if platform.system().lower() == "windows":
     WINDOWS_SYSTEM = True
@@ -148,7 +148,7 @@ def _get_last_premiere_exe_windows():
     if not premiere_versions:
         raise OSError("Could not find an Adobe Premiere Pro version installed on this computer")
     # find last installed version
-    last_version_num = sorted([StrictVersion(v["DisplayVersion"]) for v in premiere_versions])[-1]
+    last_version_num = sorted([Version(v["DisplayVersion"]) for v in premiere_versions])[-1]
     last_version_info = [v for v in premiere_versions if v["DisplayVersion"] == str(last_version_num)][0]
     # search actual exe path
     base_path = last_version_info["InstallLocation"]

--- a/pymiere/wrappers.py
+++ b/pymiere/wrappers.py
@@ -213,7 +213,7 @@ def timecode_from_seconds(seconds, sequence):
 
 
 def get_system_sequence_presets(category="Digital SLR", resolution="1080p", preset_name="DSLR 1080p25"):
-    """
+    r"""
     To create a new sequence via qe.project.newSequence we need to give a sequence preset file (.sqpreset)
     Base presets come installed with premiere. Select one according to your footage.
     Paths examples : (versions may vary)


### PR DESCRIPTION
swapped out distutils.version.StrictVersion with packaging.version.Version to prevent the distutils errors when trying to use this package on 3.12+.

Also fixed a benign syntax error in the docstring in wrappers.py by converting a docstring to raw to prevent the \P in the windows file path from triggering the warning.